### PR TITLE
average probabilities in log scale

### DIFF
--- a/src/hdp/ProbabilityNode.java
+++ b/src/hdp/ProbabilityNode.java
@@ -645,6 +645,7 @@ public class ProbabilityNode {
 		// in this method, pkAccumulated stores the log sum
 		if (this.pkAccumulated == null) {
 			pkAccumulated = new double[nk.length];
+			nPkAccumulated = 0;
 		}
 
 		for (int k = 0; k < pkAccumulated.length; k++) {
@@ -655,6 +656,7 @@ public class ProbabilityNode {
 				pkAccumulated[k] = MathUtils.logadd(pkAccumulated[k], pk[k]);
 			}
 		}
+		nPkAccumulated ++;
 
 		if (children != null) {
 			for (int c = 0; c < children.length; c++) {

--- a/src/hdp/ProbabilityNode.java
+++ b/src/hdp/ProbabilityNode.java
@@ -668,14 +668,10 @@ public class ProbabilityNode {
 	}
 	
 	public void averagePkAccumulatedProbabilitiesInLogSpace() {
-		double sum = 0;
+		MathUtils.normalizeInLogDomain(pkAccumulated);
+		
 		for (int k = 0; k < this.pkAccumulated.length; k++) {
 			pkAccumulated[k] = FastMath.exp(pkAccumulated[k]);
-			sum += pkAccumulated[k];
-		}
-
-		for (int k = 0; k < this.pkAccumulated.length; k++) {
-			pkAccumulated[k] /= sum;
 		}
 
 		if (children != null) {

--- a/src/hdp/ProbabilityTree.java
+++ b/src/hdp/ProbabilityTree.java
@@ -176,10 +176,14 @@ public class ProbabilityTree {
 			}
 
 			if (iter >= nBurnIn ) {
-				this.recordAndAverageProbabilities();
+//				this.recordAndAverageProbabilities();
+				this.recordProbabilitiesInLogScale();
 			}
 			
 		}
+		
+		root.averagePkAccumulatedProbabilitiesInLogSpace();
+		
 		double score = logScoreTree();
 		return score;
 	}
@@ -370,6 +374,12 @@ public class ProbabilityTree {
 		} else if (tyingStrategy == 3) {
 			this.concentrationTyingStrategy = TyingStrategy.SINGLE;
 		} 
+	}
+	
+	/** averaged in log space **/
+	private void recordProbabilitiesInLogScale() {
+		root.computeProbabilitiesInLogScale();
+		root.recordProbabilitiesInLogScale();
 	}
 	
 }


### PR DESCRIPTION
In the smooth method, probabilities should be recorded and averaged in log scale to avoid underflow. 